### PR TITLE
feat: Update push url to use FCM V1

### DIFF
--- a/lib/exponent-server-sdk.rb
+++ b/lib/exponent-server-sdk.rb
@@ -83,7 +83,7 @@ module Exponent
       end
 
       def push_url
-        'https://exp.host/--/api/v2/push/send'
+        'https://exp.host/--/api/v2/push/send?useFcmV1=true'
       end
 
       def get_receipts(receipt_ids)


### PR DESCRIPTION
Added the query parameter `useFcmV1=true` to `https://api.expo.dev/v2/push/send` requests